### PR TITLE
Chore/circleci: add timeout for tests, lock node to ~v6.8.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6.6.0
+    version: 6.8.1
 dependencies:
   override:
     - gem install scss-lint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-pug-starter",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "sbolel/express-pug-starter",
   "license": "MIT",
   "homepage": "https://sbolel.github.io/express-pug-starter",
@@ -16,8 +16,8 @@
   "contributors": [],
   "main": "server/index.js",
   "engines": {
-    "node": "~6.2.2",
-    "npm": "~3.10.3"
+    "node": "~6.8.1",
+    "npm": "~3.10.8"
   },
   "scripts": {
     "debug": "./node_modules/.bin/npm-run-all ./node_modules/.bin/nodemon server/index.js",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint:standard": "./node_modules/.bin/standard",
     "pretest": "./node_modules/.bin/npm-run-all lint:standard lint:js lint:scss",
     "test": "./node_modules/.bin/cross-env NODE_ENV=test ./node_modules/.bin/npm-run-all test:cover test:report",
-    "test:cover": "./node_modules/.bin/istanbul cover node_modules/.bin/_mocha -R test/**/*",
+    "test:cover": "./node_modules/.bin/istanbul cover node_modules/.bin/_mocha -R test/**/* --timeout 5000",
     "test:report": "./node_modules/.bin/istanbul report --config .istanbul.yml --root coverage/"
   },
   "dependencies": {


### PR DESCRIPTION
### Summary of Changes

- add `--timeout 5000` to npm `test` script
- lock node to `v6.8.1` in `package.json` and `circle.yml`